### PR TITLE
fix: resolve Convex function discovery error on Vercel

### DIFF
--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -1,0 +1,1 @@
+import { mutationGeneric, queryGeneric } from "convex/server"; export const query = queryGeneric; export const mutation = mutationGeneric; export const internalQuery = queryGeneric; export const internalMutation = mutationGeneric; export const action = queryGeneric; export const internalAction = queryGeneric;

--- a/convex/poker.ts
+++ b/convex/poker.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from "convex/server";
+import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 
 export const getRoom = query({


### PR DESCRIPTION
- Ensure `convex/_generated/server.js` exists and exports standard Convex function builders (`query`, `mutation`, etc.) by re-exporting from `convex/server`.
- This fixes the "Could not find public function" error occurring in the serverless deployment.