### PR TITLE
Fix build errors on Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-ssr
 .output
 .vinxi
 *.gen.ts
+.convex_tmp

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,7 +5,7 @@ export default defineSchema({
   rooms: defineTable({
     name: v.string(),
     revealed: v.boolean(),
-    maxFib: v.number(),
+    maxFib: v.optional(v.number()),
   }).index("by_name", ["name"]),
   players: defineTable({
     roomId: v.id("rooms"),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vinxi dev",
     "start": "vinxi start",
-    "build": "CONVEX_TMPDIR=.convex_tmp npx convex deploy --cmd \"vinxi build\"",
+    "build": "mkdir -p .convex_tmp && CONVEX_TMPDIR=.convex_tmp npx convex deploy --cmd \"vinxi build\"",
     "serve": "vite preview",
     "test": "vitest run",
     "format": "biome format",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vinxi dev",
     "start": "vinxi start",
-    "build": "npx convex deploy --cmd \"vinxi build\"",
+    "build": "CONVEX_TMPDIR=.convex_tmp npx convex deploy --cmd \"vinxi build\"",
     "serve": "vite preview",
     "test": "vitest run",
     "format": "biome format",


### PR DESCRIPTION
This change addresses the build failure on Vercel. 
1. It makes the `maxFib` field optional in the Convex schema to unblock deployments when the database contains records without that field (as noted in the error log). 
2. It sets `CONVEX_TMPDIR` in the build command to avoid the filesystem mismatch error recommended by the Convex CLI error message.

---
*PR created automatically by Jules for task [12631082748621541262](https://jules.google.com/task/12631082748621541262) started by @alexaapetrei*