### PR TITLE
Add exit room feature with immediate player cleanup

### DIFF
--- a/convex/poker.ts
+++ b/convex/poker.ts
@@ -171,6 +171,30 @@ export const updatePlayerName = mutation({
   },
 });
 
+export const leaveRoom = mutation({
+  args: { playerId: v.id("players") },
+  handler: async (ctx, args) => {
+    const player = await ctx.db.get(args.playerId);
+    if (!player) return;
+
+    const wasGM = player.isGM;
+    const roomId = player.roomId;
+
+    await ctx.db.delete(args.playerId);
+
+    if (wasGM) {
+      const remainingPlayers = await ctx.db
+        .query("players")
+        .withIndex("by_room", (q) => q.eq("roomId", roomId))
+        .collect();
+
+      if (remainingPlayers.length > 0) {
+        await ctx.db.patch(remainingPlayers[0]._id, { isGM: true });
+      }
+    }
+  },
+});
+
 export const heartbeat = mutation({
   args: { playerId: v.id("players") },
   handler: async (ctx, args) => {

--- a/src/routes/poker.$roomId.tsx
+++ b/src/routes/poker.$roomId.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
-import { AlertCircle, Copy, Eye, Info, RefreshCw, Users } from "lucide-react";
+import { AlertCircle, Copy, Eye, Info, LogOut, RefreshCw, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 import { api } from "../../convex/_generated/api";
@@ -29,6 +29,7 @@ function PokerRoom() {
 	const heartbeatMutation = useMutation(api.poker.heartbeat);
 	const cleanOldPlayersMutation = useMutation(api.poker.cleanOldPlayers);
 	const setMaxFibMutation = useMutation(api.poker.setMaxFib);
+	const leaveRoomMutation = useMutation(api.poker.leaveRoom);
 
 	const [playerId, setPlayerId] = useState<any>(() => {
 		if (typeof window !== "undefined") {
@@ -112,6 +113,14 @@ function PokerRoom() {
 			localStorage.setItem("poker_nickname", newNickname.trim());
 			setNickname(newNickname.trim());
 		}
+	};
+
+	const handleExitRoom = async () => {
+		if (playerId) {
+			await leaveRoomMutation({ playerId: playerId as any });
+		}
+		localStorage.removeItem(`poker_playerId_${roomName}`);
+		navigate({ to: "/" });
 	};
 
 	const copyRoomLink = () => {
@@ -200,6 +209,14 @@ function PokerRoom() {
 				</div>
 
 				<div className="flex items-center space-x-2 shrink-0">
+					<button
+						type="button"
+						onClick={handleExitRoom}
+						title="Exit room"
+						className="p-2 bg-gray-800 hover:bg-red-900/60 rounded-lg text-gray-400 hover:text-red-400 transition border border-gray-700"
+					>
+						<LogOut className="w-4 h-4" />
+					</button>
 					<button
 						type="button"
 						onClick={copyRoomLink}


### PR DESCRIPTION
- Add leaveRoom mutation that deletes the player and reassigns GM if needed
- Add LogOut button in room header that calls leaveRoom, clears localStorage, and navigates to /

https://claude.ai/code/session_014tRgcfeScc2s42BNf2AWiz