### PR TITLE
fix: prevent crash when entering room due to unsafe error handling

### DIFF
--- a/src/routes/poker.$roomId.tsx
+++ b/src/routes/poker.$roomId.tsx
@@ -45,14 +45,21 @@ function PokerRoom() {
 	useEffect(() => {
 		if (!joined && roomData !== undefined && nickname) {
 			joinRoom({ roomName, nickname, playerId: playerId || undefined })
-				.then(({ playerId: newPlayerId }) => {
+				.then((result) => {
+					if (!result) return;
+					const { playerId: newPlayerId } = result;
 					setPlayerId(newPlayerId);
 					setJoined(true);
 					localStorage.setItem(`poker_playerId_${roomName}`, newPlayerId);
 				})
 				.catch((err) => {
-					if (err.message.includes("Nickname is already taken")) {
+					if (err?.message?.includes("Nickname is already taken")) {
 						setJoinError("taken");
+					} else {
+						// Clear a potentially stale/invalid player ID so the next
+						// attempt starts fresh instead of crashing again.
+						localStorage.removeItem(`poker_playerId_${roomName}`);
+						setPlayerId(null);
 					}
 				});
 		}


### PR DESCRIPTION
Two bugs caused "undefined is not an object (evaluating 'a[or]')" crash:

1. The .catch() handler accessed err.message.includes(...) without null
   checking err or err.message. Any non-standard error (e.g. a Convex
   internal error, network error, or undefined rejection value) would
   crash here because 'message' is accessed on undefined.
   Fixed by using optional chaining: err?.message?.includes(...)

2. The .then() handler destructured { playerId } directly from the
   mutation result. If the result was ever undefined, the destructuring
   would throw the same crash.
   Fixed by extracting result first and guarding with an early return.

Also added recovery logic: on any unexpected join error the stale/invalid
playerId is cleared from localStorage so the next render retries cleanly
with a fresh player ID instead of looping on the same bad value.

https://claude.ai/code/session_01KYYX7GPgWnbwZTMXnYqb5s