### PR TITLE
fix: add missing leaveRoom and updatePlayerName to generated API

### DIFF
--- a/convex/_generated/api.ts
+++ b/convex/_generated/api.ts
@@ -8,5 +8,7 @@ export const api: any = {
     heartbeat: "poker:heartbeat",
     cleanOldPlayers: "poker:cleanOldPlayers",
     setMaxFib: "poker:setMaxFib",
+    leaveRoom: "poker:leaveRoom",
+    updatePlayerName: "poker:updatePlayerName",
   }
 };


### PR DESCRIPTION
api.poker.leaveRoom was undefined because it was not included in the
generated API object, causing useMutation(api.poker.leaveRoom) to throw
"undefined is not an object" on page load.

https://claude.ai/code/session_01BcQx1HZ9e6K4hFHp2vR2eP